### PR TITLE
Add reading headers option and fix error stack

### DIFF
--- a/lib/API.js
+++ b/lib/API.js
@@ -27,6 +27,7 @@ let express = require('express'),
  * @param {?Boolean} options.isRest
  * @param {?Boolean} options.hasApiKeyAuth
  * @param {?Boolean} options.hasOAuth
+ * @param {Array<Strings>} options.headersToBody
  * @param {?Function} options.checkId
  */
 function API(lifted, options) {
@@ -132,6 +133,12 @@ function API(lifted, options) {
 	 * @private
 	 */
 	this._hasOAuth = options.hasOAuth
+
+	/**
+	 * @member {Array<String>}
+	 * @private
+	 */
+	this._headersToBody = options.headersToBody
 
 	/**
 	 * @member {?Function}
@@ -537,6 +544,16 @@ API.prototype._addParamsToBody = function (req, body) {
 		if (req.get('Authorization')) {
 			body.Authorization = req.get('Authorization')
 		}
+	}
+
+	// Get Headers params and send as body info
+	if (this._headersToBody && this._headersToBody.length) {
+		this._headersToBody.forEach(h => {
+			if (req.get(h)) {
+				body[h] = req.get(h)
+			}
+		})
+
 	}
 
 	return body

--- a/lib/APIError.js
+++ b/lib/APIError.js
@@ -14,6 +14,9 @@ function APIError(message) {
 
 	/** @member {number} */
 	this.HTTPStatusCode = 0
+
+	/** @member {Object} */
+	this.stack = new Error(message).stack
 }
 
 // new APIError instanceof Error === true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "api-lift",
-	"version": "8.0.4",
+	"version": "8.0.5",
 	"author": "Sitegui <sitegui@sitegui.com.br>",
 	"description": "Create a ready-to-go express router for a REST API with filters, input validation, output checking, versioning, automatic routes and logging",
 	"main": "./index.js",


### PR DESCRIPTION
- Now we can select which headers to be parsed and sent as body to our actions
- Also we can follow the stack for APIError